### PR TITLE
fixed wrong namespace

### DIFF
--- a/Twig/SlugifyExtension.php
+++ b/Twig/SlugifyExtension.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Zenstruck\SlugifyBundle\Twig;
+namespace HappyR\SlugifyBundle\Twig;
 
 use HappyR\SlugifyBundle\Services\SlugifyService;
 


### PR DESCRIPTION
fixes: [RuntimeException]
  The autoloader expected class "HappyR\SlugifyBundle\Twig\SlugifyExtension" to be defined in file ...
